### PR TITLE
Fix tsconfig and package types reference.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "lib/baselet.cjs.js",
   "module": "lib/baselet.js",
   "browser": "lib/baselet.web.js",
-  "types": "lib/src/index.d.ts",
+  "types": "lib/index.d.ts",
   "scripts": {
     "fix": "npm run lint -- --fix",
     "lint": "eslint .",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,5 @@
 
     "strict": true
   },
-  "exclude": ["node_modules", "lib"]
+  "include": ["src"]
 }


### PR DESCRIPTION
It:
* Fixes the tsconfig file to only include files from the `src` directory when compiling
* Type definitions are then compiled to the root of the `libs` directory