### PR TITLE
RangeBase size defaults

### DIFF
--- a/src/RangeBase.ts
+++ b/src/RangeBase.ts
@@ -24,8 +24,8 @@ export interface RangeBase {
   queryByCount(partition: string, count: number, offset: number): Promise<any[]>
   delete(partition: string, range: number, id: string): Promise<any>
   update(partition: string, oldRange: number, newData: any): Promise<unknown>
-  min(partition: string): undefined | number
-  max(partition: string): undefined | number
+  min(partition: string): number
+  max(partition: string): number
   size(partition: string): number
   dumpData(partition: string): Promise<any>
 }

--- a/src/RangeBase.ts
+++ b/src/RangeBase.ts
@@ -541,13 +541,13 @@ export function openRangeBase(
           })
       },
       min(partition: string): undefined | number {
-        return configData.limits[partition]?.minRange
+        return configData.limits[partition]?.minRange ?? 0
       },
       max(partition: string): undefined | number {
-        return configData.limits[partition]?.maxRange
+        return configData.limits[partition]?.maxRange ?? 0
       },
       size(partition: string): number {
-        return configData.sizes[partition]
+        return configData.sizes[partition] ?? 0
       },
       dumpData(partition: string): Promise<any> {
         const min = fns.min(partition) ?? 0

--- a/src/RangeBase.ts
+++ b/src/RangeBase.ts
@@ -540,10 +540,10 @@ export function openRangeBase(
             return fns.insert(partition, newData)
           })
       },
-      min(partition: string): undefined | number {
+      min(partition: string): number {
         return configData.limits[partition]?.minRange ?? 0
       },
-      max(partition: string): undefined | number {
+      max(partition: string): number {
         return configData.limits[partition]?.maxRange ?? 0
       },
       size(partition: string): number {

--- a/test/RangeBase.test.ts
+++ b/test/RangeBase.test.ts
@@ -229,8 +229,8 @@ describe('RangeBase min/max limits', function () {
     expect(rangebaseDb.max(partitionName)).equal(max)
   }
 
-  it('should have undefined min and max values', function () {
-    testMinMax(undefined, undefined)
+  it('should have 0 min and max values', function () {
+    testMinMax(0, 0)
   })
 
   describe('inserting data', function () {
@@ -277,7 +277,7 @@ describe('RangeBase min/max limits', function () {
         testData2[rangeKey],
         testData2[idKey]
       )
-      testMinMax(undefined, undefined)
+      testMinMax(0, 0)
     })
   })
 })


### PR DESCRIPTION
### RangeBase size, min and max Defaults
The size functions for `RangeBase` are expected to return a number, but if there is no data, then it returns `undefined`. Instead, when there is no data, the functions default to `0` instead.