### PR TITLE
Return empty result set for empty queries in HashBase

### DIFF
--- a/src/HashBase.ts
+++ b/src/HashBase.ts
@@ -53,10 +53,8 @@ export async function openHashBase<K>(
     hashes: string[],
     remove = false
   ): Promise<Array<K | undefined>> {
-    if (hashes.length < 1) {
-      return Promise.reject(
-        new Error('At least one hash is required to query database.')
-      )
+    if (hashes.length === 0) {
+      return []
     }
     const { prefixSize } = configData
     const bucketFetchers = []


### PR DESCRIPTION
This changes the behavior from throwing an exception when passed an empty array of hashes to the query method on a HashBase.